### PR TITLE
Fix for BSD mktemp

### DIFF
--- a/vimcat
+++ b/vimcat
@@ -160,7 +160,7 @@ EOF
 init_tempfile() {
   # Do once
   # The ansi color coded output is stored in a temporary file
-  [ -z "$tmpfile" ] && tmpfile="$(mktemp "${TMPDIR-/tmp/}tmp.XXXXXXXXXX")"
+  [ -z "$tmpfile" ] && tmpfile="$(mktemp "${TMPDIR-/tmp}/vimcat.XXXXXXXXXX")"
 }
 
 teardown() {


### PR DESCRIPTION
`template` must be provided when using BSD mktemp.  This fix works on both GNU and BSD versions.
